### PR TITLE
Resolve initial CI issues

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -7,9 +7,6 @@ updates:
     reviewers: [ rjacraft/nevermore-developer ]
     allow:
       - dependency-type: indirect
-    ignore:
-      - dependency-name: "*"
-        update-types: [ version-update:semver-patch ]
     schedule:
       interval: daily
       time: "10:00"

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -6,7 +6,8 @@ updates:
     open-pull-requests-limit: 10
     reviewers: [ rjacraft/nevermore-developer ]
     allow:
-      - dependency-type: indirect
+      - dependency-type: all
+    versioning-strategy: lockfile-only
     schedule:
       interval: daily
       time: "10:00"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,6 +1,8 @@
 name: Publish
 
-on: [ release ]
+on:
+  release:
+    types: [ created ]
 
 jobs:
   publish:


### PR DESCRIPTION
# Description

This fixes:

* Dependabot ignoring patch updates of crates by making it only touch lockfile, but for all dependencies;
* GitHub Actions running `Publish` job multiple times by making it only run on release creation.