### PR TITLE
Make `thiserror` a dev-dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,4 +21,6 @@ proc-macro = true
 [dependencies]
 syn = "2.0"
 quote = "1.0"
+
+[dev-dependencies]
 thiserror = "1.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,6 +29,7 @@ use syn::{parse_macro_input, DeriveInput, GenericParam, Generics};
 ///     username: String,
 ///     age: u8,
 /// }
+///
 /// assert_from_never::<User>();
 /// ```
 ///


### PR DESCRIPTION
# Description

This makes `thiserror` a dev-dependency since it is only required for a doctest.
